### PR TITLE
Refactor date-timezone conversion to fix DB incompatibilities with Log utility

### DIFF
--- a/src/utilities/NotificationLog.php
+++ b/src/utilities/NotificationLog.php
@@ -15,6 +15,7 @@ use Craft;
 use craft\base\Utility;
 use craft\helpers\DateTimeHelper;
 use DateTime;
+use DateTimeZone;
 use doublesecretagency\notifier\records\Log;
 use Exception;
 
@@ -131,15 +132,17 @@ class NotificationLog extends Utility
         $dayLog = [];
 
         // Get system timezone
-        $timeZone = Craft::$app->timeZone;
+        $systemTimeZone = new DateTimeZone(Craft::$app->timeZone);
+        $dateObj = new DateTime($date, $systemTimeZone);
 
-        // Convert dateCreated to the system timezone
-        $dateCreated = "DATE(CONVERT_TZ(dateCreated, 'UTC', '{$timeZone}'))";
+        // Start and end of the day in system timezone
+        $startOfDay = (clone $dateObj)->setTime(0, 0, 0)->format('Y-m-d H:i:s');
+        $endOfDay = (clone $dateObj)->setTime(23, 59, 59)->format('Y-m-d H:i:s');
 
         // Get all envelopes on selected day
         $envelopes = Log::find()
-            ->where([$dateCreated => $date])
-            ->andWhere(['type' => 'envelope'])
+            ->where(['type' => 'envelope'])
+            ->andWhere(['between', 'dateCreated', $startOfDay, $endOfDay])
             ->orderBy('id')
             ->all();
 


### PR DESCRIPTION
While evaluating this plugin, notification logs weren't showing up for me at all locally. Narrowed it down to the `CONVERT_TZ` SQL function being the culprit (maybe an incompatibility with MariaDB / MySQL versions?). After a lengthy discussion with our robotic AI overlords, I was able to accomplish the same timezone conversion using PHP and was able to see my logs!

AI generated summary below:

--------
This pull request updates the way log records are filtered by date in the `NotificationLog` utility. Instead of relying on SQL timezone conversion, it now uses PHP's `DateTime` and `DateTimeZone` classes to compute the start and end of the selected day in the system timezone, ensuring more accurate and reliable date filtering.

**Improvements to date filtering and timezone handling:**

* Added import for `DateTimeZone` and updated logic to use PHP's `DateTime` and `DateTimeZone` for determining the start and end of the selected day in the system timezone (`src/utilities/NotificationLog.php`).
* Modified the log retrieval query to use a `BETWEEN` condition on `dateCreated` using the computed start and end of day, replacing the previous SQL `CONVERT_TZ` approach (`src/utilities/NotificationLog.php`).